### PR TITLE
feat: improve robustness of GGA parser

### DIFF
--- a/standard/gga.go
+++ b/standard/gga.go
@@ -12,7 +12,7 @@ type GGA struct {
 	HDOP                             nmea.Optional[float64]
 	Alt                              nmea.Optional[float64]
 	HeightOfGeoidAboveWGS84Ellipsoid nmea.Optional[float64]
-	TimeSinceLastDGPSUpdate          nmea.Optional[int]
+	TimeSinceLastDGPSUpdate          nmea.Optional[float64]
 	DGPSReferenceStationID           string
 }
 
@@ -27,7 +27,7 @@ func ParseGGA(addr string, tok *nmea.Tokenizer) (*GGA, error) {
 	gga.HDOP = tok.CommaOptionalUnsignedFloat()
 	gga.Alt = tok.CommaOptionalFloatCommaUnit('M')
 	gga.HeightOfGeoidAboveWGS84Ellipsoid = tok.CommaOptionalFloatCommaUnit('M')
-	gga.TimeSinceLastDGPSUpdate = tok.CommaOptionalUnsignedInt()
+	gga.TimeSinceLastDGPSUpdate = tok.CommaOptionalFloat()
 	gga.DGPSReferenceStationID = tok.CommaString()
 	tok.EndOfData()
 	return &gga, tok.Err()

--- a/standard/standard_test.go
+++ b/standard/standard_test.go
@@ -81,6 +81,25 @@ func TestUblox(t *testing.T) {
 				},
 			},
 			{
+				S: "$GPGGA,092725.00,4717.11399,N,00833.91590,E,1,08,1.01,499.6,M,48.0,M,145.5,*70",
+				Expected: &standard.GGA{
+					Address: nmea.NewAddress("GPGGA"),
+					TimeOfDay: nmea.NewOptional(nmea.TimeOfDay{
+						Hour:   9,
+						Minute: 27,
+						Second: 25,
+					}),
+					Lat:                              nmea.NewOptional(47.285233166666664),
+					Lon:                              nmea.NewOptional(8.565265),
+					FixQuality:                       1,
+					NumberOfSatellites:               nmea.NewOptional(8),
+					HDOP:                             nmea.NewOptional(1.01),
+					Alt:                              nmea.NewOptional(499.6),
+					HeightOfGeoidAboveWGS84Ellipsoid: nmea.NewOptional(48.0),
+					TimeSinceLastDGPSUpdate:          nmea.NewOptional(145.5),
+				},
+			},
+			{
 				S: "$GPGLL,4717.11364,N,00833.91565,E,092321.00,A,A*60",
 				Expected: &standard.GLL{
 					Address: nmea.NewAddress("GPGLL"),
@@ -1181,7 +1200,7 @@ func TestNovatel(t *testing.T) {
 					HDOP:                             nmea.NewOptional(0.5),
 					Alt:                              nmea.NewOptional(1097.36),
 					HeightOfGeoidAboveWGS84Ellipsoid: nmea.NewOptional(-17.0),
-					TimeSinceLastDGPSUpdate:          nmea.NewOptional(18),
+					TimeSinceLastDGPSUpdate:          nmea.NewOptional(18.0),
 					DGPSReferenceStationID:           "TSTR",
 				},
 			},


### PR DESCRIPTION
Some u-blox devices (ancient TIM-LA-0-000 in my case), report DGPS age as a fractional number. GGA parser complains as it expects the number to be an int.